### PR TITLE
Removing ValueFromPipeline

### DIFF
--- a/Cloud-App-Security.psm1
+++ b/Cloud-App-Security.psm1
@@ -1184,7 +1184,7 @@ function Send-CASDiscoveryLog
     Param
     (
         # The full path of the Log File to be uploaded, such as 'C:\mylogfile.log'.
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true, Position=0)]
+        [Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true, Position=0)]
         [Validatescript({Test-Path $_})]
         [string]$LogFile,
         


### PR DESCRIPTION
Having both ValueFromPipeline and ValueFromPipelineByPropertyname is
causing issues when trying to pass objects via the pipeline. The LogFile
parameter will disappear and not be available. Removing
ValueFromPipeline fixes this.
